### PR TITLE
Close the tunnel at the end of GitHub Actions Job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,6 @@ jobs:
 
         run: npm test
 
-      - name: Stop Tunnel
-        run: curl  -X DELETE http://127.0.0.1:${{ steps.tunnel.outputs.port }}/api/v1.0/stop
-
       - name: Export Tunnel Logs for debugging
         uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
         steps:
             # ...
             -name: Start Tunnel
-             uses: actions/lambdatest-tunnel-action@v1.0.0
+             uses: LambdaTest/LambdaTest-tunnel-action@v1.0.0
              id: tunnel
              with:
                user: ${{ secrets.LT_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -19,18 +19,13 @@ jobs:
         steps:
             # ...
             -name: Start Tunnel
-             uses: LambdaTest/LambdaTest-tunnel-action@v1.0.0
+             uses: LambdaTest/LambdaTest-tunnel-action@v1.1.0
              id: tunnel
              with:
                user: ${{ secrets.LT_EMAIL }}
                accessKey: ${{ secrets.LT_ACCESS_KEY }}
                tunnelName: "testTunnel"
             - run: npm test
-              
-            # Gracefully close the tunnel  
-            - name: Stop Tunnel
-              run: curl  -X DELETE http://127.0.0.1:${{ steps.tunnel.outputs.port }}/api/v1.0/stop
-
             - name: Export Tunnel Logs for debugging
               uses: actions/upload-artifact@v2
               with:

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,7 @@ outputs:
 runs:
   using: "node12"
   main: "dist/index.js"
+  post: "dist/index.js"
   
 branding:
   icon: 'wifi'  

--- a/dist/index.js
+++ b/dist/index.js
@@ -105,13 +105,34 @@ const core = __importStar(__webpack_require__(470));
 const crypto_1 = __importDefault(__webpack_require__(417));
 const get_port_1 = __importDefault(__webpack_require__(923));
 const child_process_1 = __importDefault(__webpack_require__(129));
+/**
+ * Name of state that stores port number of the tunnel
+ */
+const STATE_PORT = 'port';
 function run() {
+    return __awaiter(this, void 0, void 0, function* () {
+        /**
+         * The environment variable that is defined only when post script is running
+         * @see https://github.com/actions/checkout/blob/v2.3.1/src/state-helper.ts#L6
+         */
+        let isPost = !!process.env['STATE_isPost'];
+        if (isPost) {
+            cleanup();
+        }
+        else {
+            launch();
+        }
+    });
+}
+exports.run = run;
+function launch() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             let port = yield get_port_1.default();
             let name = crypto_1.default.randomBytes(10).toString("hex");
             core.setOutput("port", port);
             core.setOutput("logFileName", name);
+            core.saveState(STATE_PORT, port);
             let params = (yield getTunnelParams(port)).join(" ");
             let dockerPullCmd = "docker pull lambdatest/tunnel:latest";
             core.info(dockerPullCmd);
@@ -139,7 +160,6 @@ function run() {
         }
     });
 }
-exports.run = run;
 function getTunnelParams(port) {
     return __awaiter(this, void 0, void 0, function* () {
         let params = [];
@@ -178,6 +198,15 @@ function getTunnelParams(port) {
         }
         params.push("--controller", "github", "--infoAPIPort", `${port}`);
         return params;
+    });
+}
+function cleanup() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let port = core.getState(STATE_PORT);
+        let stopTunnelCmd = `curl -X DELETE http://127.0.0.1:${port}/api/v1.0/stop`;
+        core.info('Gracefully close the tunnel:');
+        core.info(stopTunnelCmd);
+        child_process_1.default.execSync(stopTunnelCmd, { stdio: "inherit" });
     });
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -111,12 +111,7 @@ const child_process_1 = __importDefault(__webpack_require__(129));
 const STATE_PORT = 'port';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        /**
-         * The environment variable that is defined only when post script is running
-         * @see https://github.com/actions/checkout/blob/v2.3.1/src/state-helper.ts#L6
-         */
-        let isPost = !!process.env['STATE_isPost'];
-        if (isPost) {
+        if (!!core.getState(STATE_PORT)) {
             cleanup();
         }
         else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lambdatest-tunnel-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambdatest-tunnel-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Github Action to launch LambdaTest Tunnel",
   "main": "./lib/setup-tunnel.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,7 @@ import childProcess from "child_process";
 const STATE_PORT = 'port';
 
 export async function run() {
-  /**
-   * The environment variable that is defined only when post script is running
-   * @see https://github.com/actions/checkout/blob/v2.3.1/src/state-helper.ts#L6
-   */
-  let isPost = !!process.env['STATE_isPost'];
-  if (isPost) {
+  if (!!core.getState(STATE_PORT)) {
     cleanup();
   } else {
     launch();


### PR DESCRIPTION
Currently, this action requests users to stop the tunnel manually.
It makes the workflow file noisy and unfocused, so I want to suggest this change which automates graceful shutdown.

You can [refer my workflow to grasp how updated action will run](https://github.com/KengoTODA/javadocky/runs/792573571).

I put this feature not into new file but into `main.ts`, because this project uses `@zeit/ncc` which compiles everything into one file.
The official [actions/checkout](https://github.com/actions/checkout/blob/28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b/src/main.ts) action also uses this way.